### PR TITLE
[Fullstack] Make sure 1-interviewer events work full flow 

### DIFF
--- a/backend-server/package-lock.json
+++ b/backend-server/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "backend-server",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/frontend-react/src/components/CreateLinkPage.tsx
+++ b/frontend-react/src/components/CreateLinkPage.tsx
@@ -177,6 +177,7 @@ export default function CreateLinkPage() {
                       {lead.leadName}{" "}
                     </option>
                   ))}
+                  <option value={undefined} key={undefined}>No Partner</option>
                 </select>
               </label>
             </div>

--- a/frontend-react/src/components/demo/PageThree.tsx
+++ b/frontend-react/src/components/demo/PageThree.tsx
@@ -41,12 +41,21 @@ export default function PageThree() {
     // TOOD : Request to get merged availabilities
     // TODO : Set state so that we have the availability?
     try {
+      let lead2_UID, response;
+
       const lead1_UID = eventBody["leads"][0]["leadUID"];
-      const lead2_UID = eventBody["leads"][1]["leadUID"];
-      const response = await fetch(
-        linkPrefix +
-          `availabilities/mergedTimes/?organization=${organization}&interviewerUID1=${lead1_UID}&interviewerUID2=${lead2_UID}`
-      );
+      if (eventBody["leads"].length === 1) {
+        response = await fetch(
+          linkPrefix + `availabilities/calendarAvailabilities?organization=${organization}&interviewerUID=${(lead1_UID)}`
+        )
+      } else {
+        lead2_UID = eventBody["leads"][1]["leadUID"];
+        response = await fetch(
+          linkPrefix +
+            `availabilities/mergedTimes/?organization=${organization}&interviewerUID1=${lead1_UID}&interviewerUID2=${lead2_UID}`
+        );
+      }
+
       if (!response.ok) {
         alert("Get Event request failed");
       }

--- a/frontend-react/src/components/demo/PageThree.tsx
+++ b/frontend-react/src/components/demo/PageThree.tsx
@@ -59,6 +59,7 @@ export default function PageThree() {
       if (!response.ok) {
         alert("Get Event request failed");
       }
+      
       const data = await response.json();
       setAvailabilities(data);
       console.log(data);


### PR DESCRIPTION
- added dropdown menu option: "No partner"
- selecting the no partner option now calls get availabilities for the interviewer that is signed-in
- interviewee link displays all available time slots of that one interviewer (merge availabilities is never called)