### PR TITLE
[backend] error if booked request avails != booked db avails

### DIFF
--- a/backend-server/src/api/data/dataAccess.ts
+++ b/backend-server/src/api/data/dataAccess.ts
@@ -10,11 +10,7 @@ import {
   runTransaction,
   Transaction,
 } from "@firebase/firestore";
-import { 
-  setDoc,
-  getDocs,
-  Timestamp 
-} from "firebase/firestore";
+import { setDoc, getDocs } from "firebase/firestore";
 import { db } from "../../firebase/db";
 import { Availability, Interviewer, Event } from "./models";
 
@@ -203,14 +199,14 @@ class DataAccess {
       interviewerUID
     );
 
-    collectionRef.forEach(async (availability) => {
+    for (const availability of collectionRef.docs) {
       const docRef = doc(
         interviewerRef,
         this.availabilityCollectionName,
         availability.id
       );
       await deleteDoc(docRef);
-    });
+    }
   }
 
   async eventDocRef(
@@ -322,7 +318,7 @@ class DataAccess {
       return false;
     }
   }
-  
+
   async getOrganizationFields(organization: string) {
     const organizationRef = await doc(this.rootCollection, organization);
     const organizationDoc = await getDoc(organizationRef);

--- a/frontend-react/src/components/CreateLinkPage.tsx
+++ b/frontend-react/src/components/CreateLinkPage.tsx
@@ -5,6 +5,7 @@ import moment from "moment";
 import "../App.css";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import { useAuth } from "../contexts/AuthContext";
+import { endOfWeek, startOfWeek } from "date-fns";
 
 const localizer = momentLocalizer(moment);
 
@@ -238,8 +239,8 @@ export default function CreateLinkPage() {
               startAccessor="start"
               endAccessor="end"
               style={{ height: 500 }}
-              min={new Date(2021, 11, 11, 7, 0)}
-              max={new Date(2021, 11, 11, 21, 0)}
+              min={startOfWeek(new Date())}
+              max={endOfWeek(new Date())}
               // uncomment this for custom rendering of events
               // components={{
               //   event: existingEvents,

--- a/frontend-react/src/components/InterviewerCalendar.tsx
+++ b/frontend-react/src/components/InterviewerCalendar.tsx
@@ -111,7 +111,13 @@ export default function InterviewerCalendar({ localizer }: Props) {
       "http://localhost:8080/v1/availabilities/",
       submitCalendarEvents
     );
-    console.log(response);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      alert(errorText);
+      return;
+    }
+
     try {
       const data = await response.json();
       console.log("data");


### PR DESCRIPTION
This PR adds error checking for the following flow:
* Interviewer A and interviewer B schedule availabilities with overlap. 
* An event link is created for interviewer A and B
* A interview is booked for interviewer A and B -- **Interviewer A does not refresh their page**
* Interviewer A attempts to remove the slot that was just booked, but the backend server throws and error and the frontend is notified

<img width="777" alt="Screen Shot 2022-02-24 at 7 41 43 PM" src="https://user-images.githubusercontent.com/63937200/155652720-ade773d1-6246-45fe-ae12-46bf4954e2c7.png">

EDIT: i'll remove the console.logs 🤦 