### PR TITLE
New mergeMultiple endpoint, GET availabilities deletes old ones, other bug fixes

### DIFF
--- a/backend-server/src/api/controllers/availabilityController.ts
+++ b/backend-server/src/api/controllers/availabilityController.ts
@@ -37,7 +37,6 @@ export interface GetMergedRoutesParams {
 export interface GetMultipleMergedRoutesParams {
   organization: string;
   interviewerUIDs: string[];
-  hoursBuffer: number
 }
 
 export async function addAvailability(body: AddAvailabilityBody) {

--- a/backend-server/src/api/controllers/availabilityController.ts
+++ b/backend-server/src/api/controllers/availabilityController.ts
@@ -34,6 +34,11 @@ export interface GetMergedRoutesParams {
   interviewerUID2: string;
 }
 
+export interface GetMultipleMergedRoutesParams {
+  organization: string;
+  interviewerUIDs: string[];
+}
+
 export async function addAvailability(body: AddAvailabilityBody) {
   const availability: Availability = {
     interviewerUID: body.interviewerUID,

--- a/backend-server/src/api/controllers/availabilityController.ts
+++ b/backend-server/src/api/controllers/availabilityController.ts
@@ -37,6 +37,7 @@ export interface GetMergedRoutesParams {
 export interface GetMultipleMergedRoutesParams {
   organization: string;
   interviewerUIDs: string[];
+  hoursBuffer: number
 }
 
 export async function addAvailability(body: AddAvailabilityBody) {
@@ -96,17 +97,19 @@ export async function getInterviewerAvailabilities(
   organization: string,
   interviewerUID: string
 ): Promise<Availability[]> {
-  return (await dataAccess.getAllAvailabilities(
+  const allAvailabilites =  await Promise.all(await dataAccess.getAllAvailabilities(
     organization,
     interviewerUID
-  )) as Availability[];
+  )).then((avails) => avails as Availability[]);
+
+  return (await dataAccess.deleteExpiredAvailabilities(organization, interviewerUID, allAvailabilites)) as Availability[];
 }
 
 export async function getInterviewerCalendarAvailabilities(
   organization: string,
   interviewerUID: string
 ): Promise<CalendarAvailability[]> {
-  const availabilities = (await dataAccess.getAllAvailabilities(
+  const availabilities = (await getInterviewerAvailabilities(
     organization,
     interviewerUID
   )) as Availability[];

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -32,30 +32,30 @@ export function findAllOverlapping(
   availabilities[0].forEach((timeSlot) => {
     let i = 1;
     let commonTime = timeSlot;
+
     const today: Date = new Date()
-    while (i < availabilities.length) {
-      commonTime = availabilities[i].find(
-        (element) => element.startTime == timeSlot.startTime
-      );
-      //check if commonTime was found and verify it is not booked
-      if (!commonTime && !timeSlot.isBooked) {
-        commonTime = null;
-        break;
-      } else {
-        const datestr: Date = new Date(timeSlot.startTime);
-        let diff: number = today.getTime() - datestr.getTime();
-        diff = Math.ceil(diff/ ( 1000 * 3600));
-        if (diff < hoursBuffer) {
+    const datestr: Date = new Date(timeSlot.startTime);
+    let diff: number = today.getTime() - datestr.getTime();
+    diff = Math.ceil(diff/ ( 1000 * 3600));
+    
+    // verify timeslot has not been booked and is not within hoursBuffer 
+    if (!timeSlot.isBooked && diff > hoursBuffer) {
+      while (i < availabilities.length) {
+        commonTime = availabilities[i].find(
+          (element) => element.startTime == timeSlot.startTime
+        );
+
+        //check if commonTime was found and verify it is not booked
+        if (!commonTime && !commonTime.isBooked) {
           commonTime = null;
           break;
         } else {
-          i++;
-        }        
+          i++       
+        }
+      } 
+      if (commonTime) {
+        output.push(commonTime);
       }
-    }
-    
-    if (commonTime) {
-      output.push(commonTime);
     }
   })
 

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -1,4 +1,4 @@
-import { Availability, CalendarAvailability } from "../data/models";
+import { Availability, CalendarAvailability, OrganizationFields } from "../data/models";
 import { dataAccess } from "../data/dataAccess";
 
 // find overlapping availabilities of interviewer pair
@@ -127,8 +127,8 @@ function findOverlappingGeneric(
   return output;
 }
 async function getHoursBuffer(organization: string): Promise<number> {
-  const eventDoc = await dataAccess.getOrganizationFields(organization);
-  console.log(eventDoc);
-  return Promise.resolve(24);
+  const OrganazationFields: OrganizationFields = await dataAccess.getOrganizationFields(organization) as OrganizationFields;
+  
+  return Promise.resolve(OrganazationFields.hoursBuffer);
 }
 

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -1,4 +1,5 @@
 import { Availability, CalendarAvailability } from "../data/models";
+import { dataAccess } from "../data/dataAccess";
 
 // find overlapping availabilities of interviewer pair
 export function findOverlapping(
@@ -20,15 +21,16 @@ export function findOverlapping(
 }
 
 // find overlapping availabilities of arbitrary number of interviewers
-export function findAllOverlapping(
+export async function findAllOverlapping(
   availabilities: Availability[][],
-): Availability[] {
+  organization: string
+): Promise<Availability[]> {
   const output: Availability[] = [];
   if (availabilities.length == 1) {
     return availabilities[0];
   } 
-  
-  const hoursBuffer = 24;
+
+  const hoursBuffer: number = await getHoursBuffer(organization);
 
   availabilities[0].forEach((timeSlot) => {
     let i = 1;
@@ -124,3 +126,9 @@ function findOverlappingGeneric(
   }
   return output;
 }
+async function getHoursBuffer(organization: string): Promise<number> {
+  const eventDoc = await dataAccess.getOrganizationFields(organization);
+  console.log(eventDoc);
+  return Promise.resolve(24);
+}
+

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -21,7 +21,8 @@ export function findOverlapping(
 
 // find overlapping availabilities of arbitrary number of interviewers
 export function findAllOverlapping(
-  availabilities: Availability[][]
+  availabilities: Availability[][],
+  hoursBuffer: number
 ): Availability[] {
   const output: Availability[] = [];
   if (availabilities.length == 1) {
@@ -31,15 +32,25 @@ export function findAllOverlapping(
   availabilities[0].forEach((timeSlot) => {
     let i = 1;
     let commonTime = timeSlot;
+    const today: Date = new Date()
     while (i < availabilities.length) {
       commonTime = availabilities[i].find(
         (element) => element.startTime == timeSlot.startTime
       );
-      if (!commonTime) {
+      //check if commonTime was found and verify it is not booked
+      if (!commonTime && !timeSlot.isBooked) {
         commonTime = null;
         break;
       } else {
-        i++;
+        const datestr: Date = new Date(timeSlot.startTime);
+        let diff: number = today.getTime() - datestr.getTime();
+        diff = Math.ceil(diff/ ( 1000 * 3600));
+        if (diff < hoursBuffer) {
+          commonTime = null;
+          break;
+        } else {
+          i++;
+        }        
       }
     }
     

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -1,5 +1,6 @@
 import { Availability, CalendarAvailability } from "../data/models";
 
+// find overlapping availabilities of interviewer pair
 export function findOverlapping(
   availabilities1: Availability[],
   availabilities2: Availability[]
@@ -14,6 +15,38 @@ export function findOverlapping(
       output.push(commonTime);
     }
   });
+
+  return output;
+}
+
+// find overlapping availabilities of arbitrary number of interviewers
+export function findAllOverlapping(
+  availabilities: Availability[][]
+): Availability[] {
+  const output: Availability[] = [];
+  if (availabilities.length == 1) {
+    return availabilities[0];
+  } 
+
+  availabilities[0].forEach((timeSlot) => {
+    let i = 1;
+    let commonTime = timeSlot;
+    while (i < availabilities.length) {
+      commonTime = availabilities[i].find(
+        (element) => element.startTime == timeSlot.startTime
+      );
+      if (!commonTime) {
+        commonTime = null;
+        break;
+      } else {
+        i++;
+      }
+    }
+    
+    if (commonTime) {
+      output.push(commonTime);
+    }
+  })
 
   return output;
 }

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -22,12 +22,13 @@ export function findOverlapping(
 // find overlapping availabilities of arbitrary number of interviewers
 export function findAllOverlapping(
   availabilities: Availability[][],
-  hoursBuffer: number
 ): Availability[] {
   const output: Availability[] = [];
   if (availabilities.length == 1) {
     return availabilities[0];
   } 
+  
+  const hoursBuffer = 24;
 
   availabilities[0].forEach((timeSlot) => {
     let i = 1;

--- a/backend-server/src/api/controllers/mergeController.ts
+++ b/backend-server/src/api/controllers/mergeController.ts
@@ -38,8 +38,8 @@ export async function findAllOverlapping(
 
     const today: Date = new Date()
     const datestr: Date = new Date(timeSlot.startTime);
-    let diff: number = today.getTime() - datestr.getTime();
-    diff = Math.ceil(diff/ ( 1000 * 3600));
+    let diff: number = datestr.getTime() - today.getTime();
+    diff = Math.ceil(diff/ ( 1000 * 3600)); 
     
     // verify timeslot has not been booked and is not within hoursBuffer 
     if (!timeSlot.isBooked && diff > hoursBuffer) {
@@ -49,7 +49,7 @@ export async function findAllOverlapping(
         );
 
         //check if commonTime was found and verify it is not booked
-        if (!commonTime && !commonTime.isBooked) {
+        if (!commonTime || commonTime.isBooked) {
           commonTime = null;
           break;
         } else {

--- a/backend-server/src/api/data/dataAccess.ts
+++ b/backend-server/src/api/data/dataAccess.ts
@@ -12,7 +12,7 @@ import {
 } from "@firebase/firestore";
 import { setDoc, getDocs } from "firebase/firestore";
 import { db } from "../../firebase/db";
-import { Availability, Interviewer, Event } from "./models";
+import { Availability, Interviewer, Event, OrganizationFields } from "./models";
 
 const DB_COLLECTION = "aymendb-destroylater";
 const INTERVIEWER_COLLECTION = "interviewers";
@@ -355,10 +355,10 @@ class DataAccess {
     }
   }
 
-  async getOrganizationFields(organization: string) {
+  async getOrganizationFields(organization: string) : Promise<OrganizationFields> {
     const organizationRef = await doc(this.rootCollection, organization);
     const organizationDoc = await getDoc(organizationRef);
-    return organizationDoc.data();
+    return organizationDoc.data() as OrganizationFields;
   }
 
   async listEvents(organization: string): Promise<DocumentData[]> {

--- a/backend-server/src/api/data/models.ts
+++ b/backend-server/src/api/data/models.ts
@@ -29,3 +29,12 @@ export interface Event {
   expires: string;
   eventUID: string;
 }
+
+export interface OrganizationFields {
+  availabilityBlockLength: number;
+  client_id: string;
+  client_secret: string;
+  availabilityExpiryDays: number;
+  hoursBuffer: number;
+  refresh_token: string;
+}

--- a/backend-server/src/api/routes/availability.ts
+++ b/backend-server/src/api/routes/availability.ts
@@ -150,7 +150,7 @@ availabilityRouter.get("/mergeMultiple", async (req, res) => {
       allAvailabilites.push(availability);
     };
 
-    const merged = findAllOverlapping(allAvailabilites);
+    const merged = await findAllOverlapping(allAvailabilites, body.organization);
 
     if (!req.query.inCalendarAvailability || req.query.inCalendarAvailability as string === "false") {
       res.json(merged);

--- a/backend-server/src/api/routes/availability.ts
+++ b/backend-server/src/api/routes/availability.ts
@@ -135,7 +135,6 @@ availabilityRouter.get("/mergeMultiple", async (req, res) => {
   const body: GetMultipleMergedRoutesParams = {
     organization: req.query.organization as string,
     interviewerUIDs: req.query.interviewerUID as string[],
-    hoursBuffer: parseInt(req.query.hoursBuffer as string)
   };
 
   try {
@@ -151,7 +150,7 @@ availabilityRouter.get("/mergeMultiple", async (req, res) => {
       allAvailabilites.push(availability);
     };
 
-    const merged = findAllOverlapping(allAvailabilites, body.hoursBuffer);
+    const merged = findAllOverlapping(allAvailabilites);
 
     if (!req.query.inCalendarAvailability || req.query.inCalendarAvailability as string === "false") {
       res.json(merged);

--- a/backend-server/src/api/routes/availability.ts
+++ b/backend-server/src/api/routes/availability.ts
@@ -135,6 +135,7 @@ availabilityRouter.get("/mergeMultiple", async (req, res) => {
   const body: GetMultipleMergedRoutesParams = {
     organization: req.query.organization as string,
     interviewerUIDs: req.query.interviewerUID as string[],
+    hoursBuffer: parseInt(req.query.hoursBuffer as string)
   };
 
   try {
@@ -150,7 +151,7 @@ availabilityRouter.get("/mergeMultiple", async (req, res) => {
       allAvailabilites.push(availability);
     };
 
-    const merged = findAllOverlapping(allAvailabilites);
+    const merged = findAllOverlapping(allAvailabilites, body.hoursBuffer);
 
     if (!req.query.inCalendarAvailability || req.query.inCalendarAvailability as string === "false") {
       res.json(merged);

--- a/backend-server/src/api/routes/availability.ts
+++ b/backend-server/src/api/routes/availability.ts
@@ -1,3 +1,4 @@
+import { sl } from "date-fns/locale";
 import express from "express";
 import {
   addAvailability,
@@ -134,12 +135,13 @@ availabilityRouter.get("/mergedTimes", async (req, res) => {
 availabilityRouter.get("/mergeMultiple", async (req, res) => {
   const body: GetMultipleMergedRoutesParams = {
     organization: req.query.organization as string,
-    interviewerUIDs: req.query.interviewerUID as string[],
+    interviewerUIDs: req.query.interviewerUID instanceof Array? req.query.interviewerUID as string[]: [req.query.interviewerUID] as string[],
   };
 
   try {
     if (!Object.values(body).every((field) => field != null))
       throw new Error(`Incomplete Request Body: ${JSON.stringify(body)}`);
+
 
     const allAvailabilites: Availability[][] = [];
     for await ( const interviewerUID of body.interviewerUIDs) {

--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend-react",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.11.4",

--- a/frontend-react/src/components/BookingPage.tsx
+++ b/frontend-react/src/components/BookingPage.tsx
@@ -55,7 +55,6 @@ export default function PageThree() {
         queryString += `&interviewerUID=${interviewerUID}`
       });
 
-
       const response = await fetch(queryString);
 
       if (!response.ok) {

--- a/frontend-react/src/components/BookingPage.tsx
+++ b/frontend-react/src/components/BookingPage.tsx
@@ -53,7 +53,7 @@ export default function PageThree() {
       let queryString = linkPrefix + `availabilities/mergeMultiple/?organization=${organization}`;
       leads.forEach((interviewerUID) => {
         queryString += `&interviewerUID=${interviewerUID}`
-      })
+      });
 
 
       const response = await fetch(queryString);

--- a/frontend-react/src/components/BookingPage.tsx
+++ b/frontend-react/src/components/BookingPage.tsx
@@ -44,20 +44,26 @@ export default function PageThree() {
   // Call get request with lead IDs from event body and return merged availabilities
   async function handleMergeAvailabilities(eventBody: any) {
     try {
-      const lead1_UID = eventBody["leads"][0]["leadUID"];
-      const lead2_UID = eventBody["leads"][1]["leadUID"];
-      setLeadUIDs([lead1_UID, lead2_UID]);
-      setConfirmedTime(eventBody["confirmedTime"]);
-      const response = await fetch(
-        linkPrefix +
-          `availabilities/mergedTimes/?organization=${organization}&interviewerUID1=${lead1_UID}&interviewerUID2=${lead2_UID}`
-      );
+      const leads: string[] = eventBody.leads.map((interviewer: any) => {
+        return interviewer.leadUID;
+      });
+
+      setLeadUIDs(leads);
+
+      let queryString = linkPrefix + `availabilities/mergeMultiple/?organization=${organization}`;
+      leads.forEach((interviewerUID) => {
+        queryString += `&interviewerUID=${interviewerUID}`
+      })
+
+
+      const response = await fetch(queryString);
+
       if (!response.ok) {
         alert("Merged availability request failed");
       }
       const data = await response.json();
       setAvailabilities(data);
-      console.log(data);
+
     } catch (e) {
       console.log(e);
       alert("Something went wrong with merged availability request");

--- a/frontend-react/src/components/CreateLinkPage.tsx
+++ b/frontend-react/src/components/CreateLinkPage.tsx
@@ -9,6 +9,8 @@ import { endOfWeek, startOfWeek } from "date-fns";
 
 const localizer = momentLocalizer(moment);
 
+const linkPrefix = "http://localhost:8080/v1/";
+
 interface CalendarEvent {
   interviewerUID: string | undefined;
   start: Date;
@@ -398,15 +400,24 @@ async function addEvent(
     return Promise.reject(err);
   }
 }
-
+// 
+function mergedAPIString(organization: string, leads: string[]) : string {
+  // return `http://localhost:8080/v1/availabilities/mergedTimes?organization=${organization}&interviewerUID1=${leadUID1}&interviewerUID2=${leadUID2}&inCalendarAvailability=true`;
+  let queryString = linkPrefix + `availabilities/mergeMultiple/?organization=${organization}`;
+  leads.forEach((interviewerUID) => {
+    queryString += `&interviewerUID=${interviewerUID}`
+  });
+  queryString += "&inCalendarAvailability=true"
+  return queryString;
+}
 async function getMergedAvailabilities(
   organization: string,
-  leadUID1: string | undefined,
+  leadUID1: string,
   leadUID2: string
 ): Promise<CalendarEvent[]> {
   try {
     const mergedRes: Response = await fetch(
-      `http://localhost:8080/v1/availabilities/mergedTimes?organization=${organization}&interviewerUID1=${leadUID1}&interviewerUID2=${leadUID2}&inCalendarAvailability=true`
+      mergedAPIString(organization, [leadUID1, leadUID2])
     );
     if (!mergedRes.ok)
       throw new Error(
@@ -447,6 +458,7 @@ async function getSingleAvailability(
 function ConvertAPICalEventsToCalEvents(
   APICalEvents: APICalendarEvent[]
 ): CalendarEvent[] {
+  console.log(APICalEvents);
   const convertedEvents: CalendarEvent[] = [];
   APICalEvents.forEach(function (event) {
     const storedEvent: CalendarEvent = {
@@ -456,6 +468,7 @@ function ConvertAPICalEventsToCalEvents(
     };
     convertedEvents.push(storedEvent);
   });
+  console.log(convertedEvents);
   return convertedEvents;
 }
 function showEventCount(selectedLeads: Lead[]): React.ReactNode {

--- a/frontend-react/src/components/booking/InterviewTimePicker.tsx
+++ b/frontend-react/src/components/booking/InterviewTimePicker.tsx
@@ -25,7 +25,9 @@ export default function InterviewTimePicker(props: Props) {
   }
 
   const handleDaySelect = function (year: number, month: number, day: number) {
-    setDisplaySlots(props.availabilities.filter(a => sameDay(a, moment(new Date(year, month, day)))) as Moment[]);
+    if (moment().isBefore(new Date(year, month, day))) {
+      setDisplaySlots(props.availabilities.filter(a => sameDay(a, moment(new Date(year, month, day)))) as Moment[]);
+    }
   }
 
   const displaySlotTimes = displaySlots.length === 0 ? "No availability" : displaySlots.map((avail) =>


### PR DESCRIPTION
Endpoint to refactor arbitrary number of leads, and refactors to call this. Merge only returns common availabilities that are past a certain number of buffer hours. Calling get on a lead's availabilities deletes ones that are older than a set time. 